### PR TITLE
Also apply secondary paredit keybindings

### DIFF
--- a/tagedit.el
+++ b/tagedit.el
@@ -209,7 +209,9 @@
 
   ;; paredit lookalikes
   (define-key html-mode-map (kbd "C-<right>") 'tagedit-forward-slurp-tag)
+  (define-key html-mode-map (kbd "C-)") 'tagedit-forward-slurp-tag)
   (define-key html-mode-map (kbd "C-<left>") 'tagedit-forward-barf-tag)
+  (define-key html-mode-map (kbd "C-}") 'tagedit-forward-barf-tag)
   (define-key html-mode-map (kbd "M-r") 'tagedit-raise-tag)
 
   ;; no paredit equivalents


### PR DESCRIPTION
Paredit has alternative (secondary) keybindings for slurp & barf; this commit adds them to tagedit.

(P.S. Wouldn't it be better if tagedit was a minor mode? Then the bindings could just be stuffed into `tagedit-mode-map`, and the whole mode could be toggled on and off.)
