### PR TITLE
Explicitly require 'sgml-mode

### DIFF
--- a/tagedit.el
+++ b/tagedit.el
@@ -107,6 +107,7 @@
 
 (require 'assoc)
 (require 's)
+(require 'sgml-mode)
 
 ;;;###autoload
 (defun tagedit-add-paredit-like-keybindings ()


### PR DESCRIPTION
This prevents byte compilation errors / warnings.
