### PR TITLE
Invalid function: te/delete-to

### DIFF
--- a/tagedit.el
+++ b/tagedit.el
@@ -654,6 +654,11 @@
   (remove-hook 'before-revert-hook 'te/conclude-tag-edit t)
   (remove-hook 'post-command-hook 'te/post-command-handler t))
 
+(defmacro te/delete-to (&rest body)
+  `(let ((beg (point)))
+     ,@body
+     (delete-region beg (point))))
+
 (defun te/delete-mirror-end-tag ()
   (save-excursion
     (goto-char (overlay-start te/mirror))
@@ -734,11 +739,6 @@
   `(let ((beg (point)))
      ,@body
      (kill-region beg (point))))
-
-(defmacro te/delete-to (&rest body)
-  `(let ((beg (point)))
-     ,@body
-     (delete-region beg (point))))
 
 (defun te/kill-remaining-tags-on-line ()
   (let ((line (line-number-at-pos)))


### PR DESCRIPTION
I have installed `tagedit` through `package.el` and whenever I type in
a singleton html tag the error "Invalid function: te/delete-to" is
signaled. This happens to me, for example, when typing an `input`
element.

This error disappears if I just evaluate the code in `tagedit.el`
using `eval-buffer`.

The accompanying commit fixes this problem for me without requiring me
to manually evaluate the code.

The easiest way that I can reproduce this is by having tagedit
installed with package.el, using `emacs -Q` and then evaluating:

``` lisp
(package-initialize)
(require 'tagedit)
(add-hook 'html-mode-hook 'tagedit-mode)
(add-hook 'tagedit-mode-hook 'tagedit-add-experimental-features)
```

And then typing `<input` into an html buffer, which produces

``` html
<input></inpu>
```

And the error in the echo area.
