### PR TITLE
Fix byte-compile warning about variables

### DIFF
--- a/tagedit.el
+++ b/tagedit.el
@@ -127,6 +127,21 @@
 (require 'dash)
 (require 'sgml-mode)
 
+(eval-when-compile
+  (defvar mc/cursor-specific-vars)
+  (defvar mc/cursor-specific-vars))
+
+(defvar tagedit-mode-map (make-sparse-keymap)
+  "Keymap for tagedit minor mode.")
+
+(defvar te/master nil)
+(defvar te/mirror nil)
+
+(make-variable-buffer-local 'te/master)
+(make-variable-buffer-local 'te/mirror)
+
+(defvar tagedit-experimental-features-on? nil)
+
 ;;;###autoload
 (defun tagedit-add-paredit-like-keybindings ()
   (interactive)
@@ -214,6 +229,8 @@
     (te/delete-mirror-end-tag)
     (te/conclude-tag-edit))
   (self-insert-command 1))
+
+(defvar te/tags-that-cannot-self-close '("div" "span" "script"))
 
 ;;;###autoload
 (defun tagedit-maybe-insert-slash ()
@@ -593,8 +610,6 @@
     (forward-char -1))
   (forward-char -1))
 
-(defvar tagedit-experimental-features-on? nil)
-
 (defun te/maybe-turn-on-tag-editing ()
   (when (and tagedit-mode tagedit-experimental-features-on?)
     (add-hook 'before-change-functions 'te/before-change-handler nil t)
@@ -624,12 +639,6 @@
             (te/create-mirror (- (te/get tag :end) (length (te/get tag :name)) 1)
                               (- (te/get tag :end) 1))))))))
 
-(defvar tagedit-mode-map nil
-  "Keymap for tagedit minor mode.")
-
-(unless tagedit-mode-map
-  (setq tagedit-mode-map (make-sparse-keymap)))
-
 (--each '(("C-k" . tagedit-kill)
           ("="   . tagedit-insert-equal)
           ("!"   . tagedit-insert-exclamation-mark)
@@ -643,16 +652,8 @@
       (te/maybe-turn-on-tag-editing)
     (te/turn-off-tag-editing)))
 
-(defvar te/tags-that-cannot-self-close '("div" "span" "script"))
-
 (defun te/looking-at-tag (tag)
   (= (point) (te/get tag :beg)))
-
-(defvar te/master nil)
-(defvar te/mirror nil)
-
-(make-variable-buffer-local 'te/master)
-(make-variable-buffer-local 'te/mirror)
 
 (defface te/master-face
   `((((class color) (background light))


### PR DESCRIPTION
- Declare variables before using them
- Declare other package variables only at compile time

```
In tagedit-add-paredit-like-keybindings:
tagedit.el:135:15:Warning: reference to free variable ‘tagedit-mode-map’

In tagedit-add-experimental-features:
tagedit.el:156:9:Warning: assignment to free variable
    ‘tagedit-experimental-features-on?’
tagedit.el:158:15:Warning: reference to free variable ‘tagedit-mode-map’

In tagedit-disable-experimental-features:
tagedit.el:166:9:Warning: assignment to free variable
    ‘tagedit-experimental-features-on?’
tagedit.el:168:15:Warning: reference to free variable ‘tagedit-mode-map’

In tagedit-maybe-insert-slash:
tagedit.el:222:41:Warning: reference to free variable
    ‘te/tags-that-cannot-self-close’

In te/maybe-turn-on-tag-editing:
tagedit.el:599:14:Warning: reference to free variable ‘tagedit-mode’

In te/before-change-handler:
tagedit.el:608:14:Warning: reference to free variable ‘te/master’

In te/maybe-start-tag-edit:
tagedit.el:616:21:Warning: reference to free variable ‘te/master’
tagedit.el:617:21:Warning: reference to free variable ‘te/mirror’

tagedit.el:1092:20:Warning: reference to free variable
    ‘mc/cursor-specific-vars’
tagedit.el:1092:20:Warning: assignment to free variable
    ‘mc/cursor-specific-vars’
```
