### PR TITLE
Correct use of eval-after-load

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Not part of paredit:
 If you want tagedit to bind to the same keys as paredit, there's this:
 
 ```cl
-(eval-after-load "sgml-mode"
+(eval-after-load 'sgml-mode
   '(progn
      (require 'tagedit)
      (tagedit-add-paredit-like-keybindings)

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -19,7 +19,7 @@
 (require 'espuds)
 (require 'ert)
 
-(eval-after-load "sgml-mode"
+(eval-after-load 'sgml-mode
   '(progn
      (tagedit-add-experimental-features)
      (tagedit-add-paredit-like-keybindings)))

--- a/tagedit.el
+++ b/tagedit.el
@@ -58,7 +58,7 @@
 ;; If you want tagedit to bind to the same keys as paredit, there's this:
 ;;
 ;; ```cl
-;; (eval-after-load "sgml-mode"
+;; (eval-after-load 'sgml-mode
 ;;   '(progn
 ;;      (require 'tagedit)
 ;;      (tagedit-add-paredit-like-keybindings)


### PR DESCRIPTION
With a symbol, only the file providing the feature triggers the
eval-after-load. With a string, any file named the same way triggers
it. This is problematic for custom configurations named after
packages.